### PR TITLE
Enable Link-Time Optimization (LTO)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,6 @@ insta = { version = "1.41.0", features = ["filters"], default-features = false }
 insta-cmd = "0.6.0"
 maplit = "1.0.2"
 regex = { version = "1.6.0", default-features = false }
+
+[profile.release]
+lto = true


### PR DESCRIPTION
Hi!

I noticed that in the `Cargo.toml` file Link-Time Optimization (LTO) for the project is not enabled. I suggest switching it on since it will reduce the binary size (which is always a good thing to have).

I have made quick tests (Fedora 41, Rustc 1.83) by adding `lto = true` to the Release profile. The binary size reduction is from 1.5 Mib to 1.3 Mib.

Thank you.